### PR TITLE
Small update.

### DIFF
--- a/EOC's/eoc_mut.json
+++ b/EOC's/eoc_mut.json
@@ -7,7 +7,13 @@
     "effect": [
       {
         "if": { "math": [ "u_gamb_ki < u_gamb_kicap" ] },
-        "then": [ { "math": [ "u_gamb_ki", "+=", "u_gamb_kireg / u_gamb_kiweak" ] } ]
+        "then": [ { "math": [ "u_gamb_ki", "+=", "u_gamb_kireg / u_gamb_kiweak" ] } ],
+        "else": [
+          {
+            "if": { "math": [ "u_gamb_ki >= u_gamb_ki" ] },
+            "then": { "u_message": "Your inner ki has reached its limit.", "type": "good" }
+          }
+        ]
       },
       {
         "if": { "and": [ { "math": [ "u_gamb_ki > ( u_gamb_kicap / 2 )" ] }, { "math": [ "u_gamb_kistage < 4" ] } ] },

--- a/EOC's/eoc_shard.json
+++ b/EOC's/eoc_shard.json
@@ -37,6 +37,7 @@
           { "math": [ "u_gamb_hpregaw", "+=", "0.001 * max(0, 10-rand(1+((u_gamb_cardiom*1000)^.3)))" ] },
           { "math": [ "u_gamb_mendmod", "+=", "0.001 * max(0, 6-rand(1+((u_gamb_cardiom*1000)^.3)))" ] },
           { "math": [ "u_gamb_kicap", "+=", "0.1 * max(0, 6-rand(sqrt(u_gamb_kicap)*5))" ] },
+          { "math": [ "u_gamb_ki", "+=", "0.01 * max(1, rand(10)" ] },
           {
             "u_message": "The shard's ki enters your body and fuses with your being. You feel stronger.",
             "type": "good"


### PR DESCRIPTION
Give ki on consuming the shard, mostly to make sure you don't accidentaly trigger the ki thresholds early on. Still possible to trigger them by increasing your ki capacity too fast. Should be increased with increased control over ki. Also added a message for your ki filling. Should do a damaging effecf for when you go too high over your limit, or bellow the 25 and 10% thresholds.