### PR TITLE
Spell EOC to Effect migration

### DIFF
--- a/EOC's/Spell_Eocs/PhySpell_EOC.json
+++ b/EOC's/Spell_Eocs/PhySpell_EOC.json
@@ -4,35 +4,21 @@
     "id": "EOC_Gamb_Breinforce",
     "effect": [
       {
-        "if": { "math": [ "u_gamb_breinforce", "==", "0" ] },
+        "if": { "not": { "u_has_effect": "effect_breinforce" } },
         "then": {
           "if": { "math": [ "u_gamb_ki", ">", "1" ] },
           "then": [
-            { "math": [ "u_gamb_kidrain", "+=", ".1" ] },
             { "math": [ "u_gamb_ki", "-=", "1" ] },
-            { "math": [ "u_gamb_breinforce", "=", "1" ] },
-            { "math": [ "u_gambtemp_speed", "+=", "10+(u_gamb_phytoken^.3)" ] },
-            { "math": [ "u_gambtemp_atkspd", "+=", "10+(u_gamb_phytoken^.3)" ] },
-            { "math": [ "u_gambtemp_bashd", "+=", "7+(u_gamb_phytoken^.25)" ] },
-            { "math": [ "u_gambtemp_painres", "+=", "5+(u_gamb_phytoken^.2)" ] },
-            { "math": [ "u_gambtemp_basha", "+=", "5+(u_gamb_phytoken^.2)" ] },
-            { "math": [ "u_gambtemp_mhit", "+=", "1+(u_gamb_phytoken^.15)" ] },
-            { "math": [ "u_gambtemp_str", "+=", "max(0,(1-(u_gamb_phytoken^.15)))" ] },
-            { "math": [ "u_gamb_phyxpg", "+=", "0.1" ] }
+            { "math": [ "u_gamb_phyxpg", "+=", "0.1" ] },
+            { "math": [ "u_gamb_kidrain", "+=", "0.1" ] },
+            { "u_add_effect": "effect_breinforce", "duration": "PERMANENT" }
           ],
           "else": { "u_message": "You don't have enough ki.", "type": "bad" }
         },
         "else": [
-          { "math": [ "u_gamb_breinforce", "=", "0" ] },
-          { "math": [ "u_gamb_kidrain", "-=", ".1" ] },
-          { "math": [ "u_gambtemp_speed", "-=", "10+(u_gamb_phytoken^.3)" ] },
-          { "math": [ "u_gambtemp_atkspd", "-=", "10+(u_gamb_phytoken^.3)" ] },
-          { "math": [ "u_gambtemp_bashd", "-=", "7+(u_gamb_phytoken^.25)" ] },
-          { "math": [ "u_gambtemp_painres", "-=", "5+(u_gamb_phytoken^.2)" ] },
-          { "math": [ "u_gambtemp_basha", "-=", "5+(u_gamb_phytoken^.2)" ] },
-          { "math": [ "u_gambtemp_mhit", "-=", "1+(u_gamb_phytoken^.15)" ] },
-          { "math": [ "u_gambtemp_str", "-=", "max(0,(1-(u_gamb_phytoken^.15)))" ] },
+          { "u_lose_effect": "effect_breinforce" },
           { "math": [ "u_gamb_phyxpg", "-=", "0.1" ] },
+          { "math": [ "u_gamb_kidrain", "-=", "0.1" ] },
           { "u_message": "You turn off you Body Reinforcement" }
         ]
       }
@@ -43,38 +29,22 @@
     "id": "EOC_Gamb_Ironscale",
     "effect": [
       {
-        "if": { "math": [ "u_gamb_ironscale", "==", "0" ] },
+        "if": { "not": { "u_has_effect": "effect_ironscale" } },
         "then": {
           "if": { "math": [ "u_gamb_ki", ">", "0.5" ] },
           "then": [
-            { "math": [ "u_gamb_kidrain", "+=", ".07" ] },
             { "math": [ "u_gamb_ki", "-=", "0.5" ] },
-            { "math": [ "u_gamb_ironscale", "=", "1" ] },
-            { "math": [ "u_gambtemp_bashd", "+=", "2+(u_gamb_phytoken^.1)" ] },
-            { "math": [ "u_gambtemp_painres", "+=", "10+(u_gamb_phytoken^.4)" ] },
-            { "math": [ "u_gambtemp_basha", "+=", "12+(u_gamb_phytoken^.6)" ] },
-            { "math": [ "u_gambtemp_cuta", "+=", "7+(u_gamb_phytoken^.55)" ] },
-            { "math": [ "u_gambtemp_staba", "+=", "5+(u_gamb_phytoken^.5)" ] },
-            { "math": [ "u_gambtemp_bulla", "+=", "3+(u_gamb_phytoken^.4)" ] },
-            { "math": [ "u_gambtemp_eleca", "+=", "2+(u_gamb_phytoken^.35)" ] },
-            { "math": [ "u_gambtemp_mhit", "+=", "1+(u_gamb_phytoken^.1)" ] },
-            { "math": [ "u_gamb_phyxpg", "+=", "0.08" ] }
+            { "math": [ "u_gamb_phyxpg", "+=", "0.08" ] },
+            { "math": [ "u_gamb_kidrain", "+=", "0.07" ] },
+            { "u_add_effect": "effect_ironscale", "duration": "PERMANENT" }
           ],
           "else": { "u_message": "You don't have enough ki.", "type": "bad" }
         },
         "else": [
-          { "math": [ "u_gamb_ironscale", "=", "0" ] },
-          { "math": [ "u_gamb_kidrain", "-=", ".07" ] },
-          { "math": [ "u_gambtemp_bashd", "-=", "2+(u_gamb_phytoken^.1)" ] },
-          { "math": [ "u_gambtemp_painres", "-=", "10+(u_gamb_phytoken^.4)" ] },
-          { "math": [ "u_gambtemp_basha", "-=", "12+(u_gamb_phytoken^.6)" ] },
-          { "math": [ "u_gambtemp_cuta", "-=", "7+(u_gamb_phytoken^.55)" ] },
-          { "math": [ "u_gambtemp_staba", "-=", "5+(u_gamb_phytoken^.5)" ] },
-          { "math": [ "u_gambtemp_bulla", "-=", "3+(u_gamb_phytoken^.4)" ] },
-          { "math": [ "u_gambtemp_eleca", "-=", "2+(u_gamb_phytoken^.35)" ] },
-          { "math": [ "u_gambtemp_mhit", "-=", "1+(u_gamb_phytoken^.1)" ] },
+          { "u_lose_effect": "effect_ironscale" },
           { "math": [ "u_gamb_phyxpg", "-=", "0.08" ] },
-          { "u_message": "You turn off you Body Reinforcement" }
+          { "math": [ "u_gamb_kidrain", "-=", "0.07" ] },
+          { "u_message": "You turn off you Ironscale" }
         ]
       }
     ]
@@ -117,21 +87,10 @@
     "type": "effect_on_condition",
     "id": "EOC_Gamb_KiOff",
     "effect": [
-      { "math": [ "u_gamb_breinforce", "=", "0" ] },
-      { "math": [ "u_gamb_ironscale", "=", "0" ] },
-      { "math": [ "u_gamb_kidrain", "=", "0" ] },
-      { "math": [ "u_gambtemp_speed", "=", "0" ] },
-      { "math": [ "u_gambtemp_atkspd", "=", "0" ] },
-      { "math": [ "u_gambtemp_bashd", "=", "0" ] },
-      { "math": [ "u_gambtemp_painres", "=", "0" ] },
-      { "math": [ "u_gambtemp_basha", "=", "0" ] },
-      { "math": [ "u_gambtemp_cuta", "=", "0" ] },
-      { "math": [ "u_gambtemp_staba", "=", "0" ] },
-      { "math": [ "u_gambtemp_bulla", "=", "0" ] },
-      { "math": [ "u_gambtemp_eleca", "=", "0" ] },
-      { "math": [ "u_gambtemp_mhit", "=", "0" ] },
-      { "math": [ "u_gambtemp_str", "=", "0" ] },
-      { "math": [ "u_gamb_phyxpg", "=", "0" ] }
+      { "u_lose_effect": "effect_breinforce" },
+      { "u_lose_effect": "effect_ironscale" },
+      { "math": [ "u_gamb_phyxpg", "=", "0" ] },
+      { "math": [ "u_gamb_kidrain", "=", "0" ] }
     ]
   }
 ]

--- a/EOC's/Spell_Eocs/WoodSpell_EOC.json
+++ b/EOC's/Spell_Eocs/WoodSpell_EOC.json
@@ -7,7 +7,7 @@
         "if": { "math": [ "u_gamb_kiwood", ">", "0.4" ] },
         "then": [
           { "math": [ "u_gamb_kiwood", "-=", "0.4" ] },
-          { "u_add_effect": "effect_woodshed", "duration": { "math": [ "5 +(u_gamb_woodtoken^0.4)" ] } },
+          { "u_add_effect": "effect_woodshed", "duration": { "math": [ "300 +((u_gamb_woodtoken^0.2)*100)" ] } },
           { "math": [ "u_gamb_woodxp", "+=", "1" ] },
           { "math": [ "u_gamb_kiwoodcap", "+=", "0.001" ] },
           { "math": [ "u_gamb_kiwoodxreg", "+=", "0.000001" ] }
@@ -15,5 +15,28 @@
         "else": { "u_message": "You don't have enough wood ki.", "type": "bad" }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_Gamb_WoodDrain",
+    "recurrence": [ "1 s", "1 s" ],
+    "condition": { "math": [ "u_gamb_kiwooddrain > 0" ] },
+    "effect": [
+      { "math": [ "u_gamb_kiwood", "-=", "u_gamb_kiwooddrain " ] },
+      { "math": [ "u_gamb_woodxp", "+=", "u_gamb_woodxpg" ] },
+      { "math": [ "u_gamb_kiwoodcap", "+=", "u_gamb_woodxpg*0.025" ] },
+      { "math": [ "u_gamb_kiwoodreg", "+=", "u_gamb_woodxpg*0.00005" ] },
+      {
+        "if": { "math": [ "u_gamb_kiwood", "<", "u_gamb_kiwooddrain" ] },
+        "then": [
+          { "u_message": "You run out of ki to sustain your wood spells.", "type": "bad" },
+          { "run_eocs": [ "EOC_Gamb_KiWoodOff" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_Gamb_KiWoodOff"
   }
 ]

--- a/EOC's/eoc_awaken.json
+++ b/EOC's/eoc_awaken.json
@@ -75,7 +75,12 @@
   {
     "type": "effect_on_condition",
     "id": "Gamb_Ki_phytokenplus",
-    "effect": [ { "math": [ "u_gamb_phytoken", "+=", "10" ] } ]
+    "effect": [ { "math": [ "u_gamb_phytoken", "+=", "100" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "Gamb_Ki_Maxed",
+    "effect": [ { "math": [ "u_gamb_kiwood", "+=", "100" ] }, { "math": [ "u_gamb_ki", "+=", "100" ] } ]
   },
   {
     "type": "effect_on_condition",
@@ -85,7 +90,7 @@
   {
     "type": "effect_on_condition",
     "id": "Gamb_Ki_phytokenminus",
-    "effect": [ { "math": [ "u_gamb_phytoken", "-=", "10" ] } ]
+    "effect": [ { "math": [ "u_gamb_phytoken", "-=", "100" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/EOC's/eoc_kiregen.json
+++ b/EOC's/eoc_kiregen.json
@@ -160,7 +160,7 @@
         }
       },
       {
-        "if": { "math": [ "u_gamb_kiwodd", ">=", "u_gamb_kicap * u_gamb_kiwoodcap" ] },
+        "if": { "math": [ "u_gamb_kiwood", ">=", "u_gamb_kicap * u_gamb_kiwoodcap" ] },
         "then": [ { "u_lose_trait": "Gamb_KiWood_Capacity" }, { "u_add_trait": "Gamb_KiWood_Capacity", "variant": "Gamb_KiWood_Full" } ],
         "else": {
           "if": { "math": [ "u_gamb_ki", ">", "(u_gamb_kicap * u_gamb_kiwoodcap)/2" ] },

--- a/Effects/Electric_effects.json
+++ b/Effects/Electric_effects.json
@@ -8,8 +8,9 @@
     "main_parts_only": true,
     "part_descs": true,
     "int_dur_factor": 10,
-    "base_mods": { "hurt_amount": [ 1 ], "hurt_chance": [ 8 ], "hurt_chance_bot": [ 10 ] },
-    "scaling_mods": { "hurt_chance": [ 1 ], "hurt_amount": [ 1 ] },
+    "max_intensity": 20,
+    "base_mods": { "hurt_min": [ 1 ], "hurt_chance": [ 8 ], "hurt_chance_bot": [ 10 ] },
+    "scaling_mods": { "hurt_chance": [ 1 ], "hurt_min": [ 1 ] },
     "enchantments": [ { "values": [ { "value": "SPEED", "add": { "math": [ "(u_effect_intensity('eff_gamb_lightningl')*-5)" ] } } ] } ]
   }
 ]

--- a/Effects/Phy_Effects.json
+++ b/Effects/Phy_Effects.json
@@ -2,16 +2,16 @@
   {
     "type": "effect_type",
     "id": "effect_phy_overload",
-    "rating": "good",
+    "rating": "bad",
     "name": [ "Overload" ],
     "desc": [ "Your body is breaking from the inner energy." ],
-    "main_parts_only": true,
     "part_descs": true,
+    "main_parts_only": true,
     "apply_message": "Your body is breaking from the inner energy.",
-    "max_intensity": 4,
+    "max_intensity": 10,
     "int_dur_factor": 10,
-    "base_mods": { "hurt_amount": [ 5 ], "hurt_chance": [ 50 ], "hurt_chance_bot": [ 100 ], "hurt_tick": [ 5 ] },
-    "scaling_mods": { "hurt_amount": [ 2 ], "hurt_chance": [ 10 ], "hurt_tick": [ -1 ] }
+    "base_mods": { "hurt_min": [ 5 ], "hurt_chance": [ 50 ], "hurt_chance_bot": [ 100 ], "hurt_tick": [ 5 ] },
+    "scaling_mods": { "hurt_min": [ 2 ], "hurt_chance": [ 10 ], "hurt_tick": [ -1 ] }
   },
   {
     "type": "effect_type",
@@ -19,8 +19,9 @@
     "rating": "good",
     "name": [ "Overloadgood" ],
     "desc": [ "Your body is booming with energy." ],
-    "main_parts_only": true,
     "part_descs": true,
+    "main_parts_only": true,
+    "max_intensity": 20,
     "int_dur_factor": 10,
     "apply_message": "Your body is booming with energy from the wild ki.",
     "remove_message": "The wild ki settles.",
@@ -29,7 +30,7 @@
         "values": [
           {
             "value": "ARMOR_ALL",
-            "add": { "math": [ "3", "+", "u_gamb_phytoken^0.2", "*", "(u_effect_intensity('effect_phy_overloadgood')^0.8)" ] }
+            "add": { "math": [ "3", "+", "u_gamb_phytoken^0.2", "*", "(u_effect_intensity('effect_phy_overloadgood')^0.6)" ] }
           },
           {
             "value": "SPEED",
@@ -55,6 +56,62 @@
             "type": "bash",
             "add": { "math": [ "((12+(u_gamb_phytoken^0.6))*(u_effect_intensity('effect_phy_overloadgood')^0.8))" ] }
           }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_ironscale",
+    "rating": "good",
+    "name": [ "Ironscalegood" ],
+    "desc": [ "Your body is covered in a steel-like layer of ki." ],
+    "part_descs": true,
+    "main_parts_only": true,
+    "apply_message": "Your body is reinforced with ki.",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "PAIN", "add": { "math": [ "(10+(u_gamb_phytoken^.4))*-1" ] } },
+          { "value": "MELEE_TO_HIT", "add": { "math": [ "1+(u_gamb_phytoken^.1)" ] } }
+        ]
+      },
+      {
+        "melee_damage_bonus": [ { "type": "bash", "add": { "math": [ "2+(u_gamb_phytoken^.1)" ] } } ],
+        "incoming_damage_mod": [
+          { "type": "bash", "add": { "math": [ "(12+(u_gamb_phytoken^.6))*-1" ] } },
+          { "type": "cut", "add": { "math": [ "(7+(u_gamb_phytoken^.55))*-1" ] } },
+          { "type": "stab", "add": { "math": [ "(5+(u_gamb_phytoken^.5))*-1" ] } },
+          { "type": "bullet", "add": { "math": [ "(3+(u_gamb_phytoken^.4))*-1" ] } },
+          { "type": "electric", "add": { "math": [ "(2+(u_gamb_phytoken^.35))*-1" ] } }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_breinforce",
+    "rating": "good",
+    "name": [ "Breinforcegood" ],
+    "desc": [ "Your body is enhanced with ki." ],
+    "part_descs": true,
+    "main_parts_only": true,
+    "apply_message": "Your body is enhanced with ki.",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "PAIN", "add": { "math": [ "(5+(u_gamb_phytoken^.2))*-1" ] } },
+          { "value": "MELEE_TO_HIT", "add": { "math": [ "1+(u_gamb_phytoken^.3)" ] } },
+          { "value": "STRENGTH", "add": { "math": [ "max(0,((u_gamb_phytoken^.2)-2))" ] } },
+          { "value": "ATTACK_SPEED", "add": { "math": [ "(3+(u_gamb_phytoken^.3)) * -1" ] } },
+          { "value": "SPEED", "add": { "math": [ "10+(u_gamb_phytoken^.3)" ] } }
+        ]
+      },
+      {
+        "melee_damage_bonus": [ { "type": "bash", "add": { "math": [ "7+(u_gamb_phytoken^.25)" ] } } ],
+        "incoming_damage_mod": [
+          { "type": "bash", "add": { "math": [ "(3+(u_gamb_phytoken^.2))*-1" ] } },
+          { "type": "cut", "add": { "math": [ "(2+(u_gamb_phytoken^.1))*-1" ] } }
         ]
       }
     ]

--- a/Effects/Wood_Effects.json
+++ b/Effects/Wood_Effects.json
@@ -5,10 +5,15 @@
     "rating": "good",
     "name": [ "WoodShed" ],
     "desc": [ "Your skin is slowly peeling off." ],
-    "main_parts_only": true,
     "part_descs": true,
-    "int_dur_factor": 10,
-    "base_mods": { "hurt_amount": [ -1 ], "hurt_chance": [ 2 ], "hurt_chance_bot": [ 20 ] },
-    "scaling_mods": { "hurt_chance": [ 1 ], "hurt_amount": [ -1 ] }
+    "main_parts_only": true,
+    "max_intensity": 20,
+    "int_dur_factor": 400,
+    "enchantments": [
+      {
+        "values": [ { "value": "REGEN_HP", "multiply": { "math": [ "15", "+", "(u_effect_intensity('effect_woodshed')*2)" ] } } ]
+      },
+      { "values": [ { "value": "REGEN_HP_AWAKE", "multiply": { "math": [ "1" ] } } ] }
+    ]
   }
 ]

--- a/Monsters/Ki_Beasts.json
+++ b/Monsters/Ki_Beasts.json
@@ -30,7 +30,8 @@
     "regen_morale": true,
     "regenerates": 3,
     "luminance": 4,
-    "armor": { "bash": 18, "cut": 10, "acid": 6, "bullet": 12, "electric": 50, "heat": 10, "cold": 15, "biological": 6 },
+    "flags": [ "SEES", "HEARS", "PATH_AVOID_DANGER", "WARM", "ANIMAL" ],
+    "armor": { "bash": 20, "cut": 12, "acid": 8, "bullet": 18, "electric": 50, "heat": 10, "cold": 15, "biological": 10 },
     "attack_effs": [ { "id": "eff_gamb_lightningl", "duration": [ 3, 8 ], "chance": 10 } ],
     "emit_fields": [ { "emit_id": "emit_gamb_lightningl", "delay": "1 s" } ],
     "anger_triggers": [ "HURT", "PLAYER_CLOSE", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ]

--- a/Mutations/mutations.json
+++ b/Mutations/mutations.json
@@ -13,21 +13,21 @@
     "enchantments": [
       {
         "melee_damage_bonus": [
-          { "type": "bash", "add": { "math": [ "u_gamb_bashd + u_gambtemp_bashd * 1" ] } },
-          { "type": "cut", "add": { "math": [ "u_gamb_cutd + u_gambtemp_cutd * 1" ] } },
-          { "type": "stab", "add": { "math": [ "u_gamb_stbd + u_gambtemp_stbd * 1" ] } },
-          { "type": "bullet", "add": { "math": [ "u_gamb_bulld+u_gambtemp_bulld * 1" ] } }
+          { "type": "bash", "add": { "math": [ "u_gamb_bashd * 1" ] } },
+          { "type": "cut", "add": { "math": [ "u_gamb_cutd * 1" ] } },
+          { "type": "stab", "add": { "math": [ "u_gamb_stbd * 1" ] } },
+          { "type": "bullet", "add": { "math": [ "u_gamb_bulld * 1" ] } }
         ],
         "incoming_damage_mod": [
-          { "type": "bash", "add": { "math": [ "(u_gamb_basha + u_gambtemp_basha) * -1" ] } },
-          { "type": "cut", "add": { "math": [ "(u_gamb_cuta + u_gambtemp_cuta) * -1" ] } },
-          { "type": "stab", "add": { "math": [ "(u_gamb_staba + u_gambtemp_staba) * -1" ] } },
-          { "type": "bullet", "add": { "math": [ "(u_gamb_bulla + u_gambtemp_bulla) * -1" ] } },
-          { "type": "cold", "add": { "math": [ "(u_gamb_colda + u_gambtemp_colda) * -1" ] } },
-          { "type": "heat", "add": { "math": [ "(u_gamb_heata + u_gambtemp_heata) * -1" ] } },
-          { "type": "electric", "add": { "math": [ "(u_gamb_eleca + u_gambtemp_eleca) * -1" ] } },
-          { "type": "acid", "add": { "math": [ "(u_gamb_acida + u_gambtemp_acida) * -1" ] } },
-          { "type": "biologicl", "add": { "math": [ "(u_gamb_bioa + u_gambtemp_bioa) * -1" ] } }
+          { "type": "bash", "add": { "math": [ "u_gamb_basha * -1" ] } },
+          { "type": "cut", "add": { "math": [ "u_gamb_cuta  * -1" ] } },
+          { "type": "stab", "add": { "math": [ "u_gamb_staba  * -1" ] } },
+          { "type": "bullet", "add": { "math": [ "u_gamb_bulla  * -1" ] } },
+          { "type": "cold", "add": { "math": [ "u_gamb_colda  * -1" ] } },
+          { "type": "heat", "add": { "math": [ "u_gamb_heata  * -1" ] } },
+          { "type": "electric", "add": { "math": [ "u_gamb_eleca  * -1" ] } },
+          { "type": "acid", "add": { "math": [ "u_gamb_acida  * -1" ] } },
+          { "type": "biologicl", "add": { "math": [ "u_gamb_bioa  * -1" ] } }
         ]
       },
       {
@@ -57,35 +57,6 @@
           { "value": "RECOIL_MODIFIER", "add": { "math": [ "u_gamb_recoil * -1" ] } },
           { "value": "MAX_HP", "add": { "math": [ "u_gamb_maxhp * 1" ] } },
           { "value": "MELEE_TO_HIT", "add": { "math": [ "u_gamb_mhit + 1" ] } }
-        ]
-      },
-      {
-        "values": [
-          { "value": "STRENGTH", "add": { "math": [ "u_gambtemp_str * 1" ] } },
-          { "value": "DEXTERITY", "add": { "math": [ "u_gambtemp_dex * 1" ] } },
-          { "value": "ATTACK_SPEED", "add": { "math": [ "u_gambtemp_atkspd * -1" ] } },
-          { "value": "NIGHT_VIS", "add": { "math": [ "u_gambtemp_nvis * 1" ] } },
-          { "value": "PAIN", "add": { "math": [ "u_gambtemp_painres * -1" ] } },
-          { "value": "PAIN_REMOVE", "add": { "math": [ "u_gambtemp_painrem * 1" ] } },
-          { "value": "CARDIO_MULTIPLIER", "multiply": { "math": [ "u_gambtemp_cardiom * 1" ] } },
-          { "value": "BONUS_BLOCK", "add": { "math": [ "u_gambtemp_blckamm * 1" ] } },
-          { "value": "BONUS_DODGE", "add": { "math": [ "u_gambtemp_dogamm * 1" ] } },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": { "math": [ "u_gambtemp_crftspd * 1" ] } },
-          { "value": "SPEED", "add": { "math": [ "u_gambtemp_speed * 1" ] } },
-          { "value": "MENDING_MODIFIER", "multiply": { "math": [ "u_gambtemp_mendmod * 1" ] } },
-          { "value": "MELEE_STAMINA_CONSUMPTION", "add": { "math": [ "u_gambtemp_meleestam * 1" ] } },
-          { "value": "KNOCKBACK_RESIST", "add": { "math": [ "u_gambtemp_knkres * 1" ] } },
-          { "value": "CLIMATE_CONTROL_HEAT", "add": { "math": [ "u_gambtemp_climate * 1" ] } },
-          { "value": "CLIMATE_CONTROL_CHILL", "add": { "math": [ "u_gambtemp_climate * 1" ] } },
-          { "value": "CONSUME_TIME_MOD", "multiply": { "math": [ "max(-0.20,(u_gambtemp_consume * -0.20))" ] } },
-          { "value": "CARRY_WEIGHT", "add": { "math": [ "u_gambtemp_carry * 1" ] } },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "add": { "math": [ "u_gambtemp_stomach * 1" ] } },
-          { "value": "STAMINA_REGEN_MOD", "add": { "math": [ "u_gambtemp_staminareg * 1" ] } },
-          { "value": "REGEN_HP", "multiply": { "math": [ "u_gambtemp_hpreg * 1" ] } },
-          { "value": "REGEN_HP_AWAKE", "multiply": { "math": [ "u_gambtemp_hpregaw * 1" ] } },
-          { "value": "RECOIL_MODIFIER", "add": { "math": [ "u_gambtemp_recoil * -1" ] } },
-          { "value": "MAX_HP", "add": { "math": [ "u_gambtemp_maxhp * 1" ] } },
-          { "value": "MELEE_TO_HIT", "add": { "math": [ "u_gambtemp_mhit * 1" ] } }
         ]
       }
     ]


### PR DESCRIPTION
-migrate spell enchants to effects. Ki drain and physical is still handled per-spell, by checking if the effect is active. This should enable per-ki--type shutdown by only removing the type specific effects and the type drain and xp gain with the Off EOC -Fix Woodshed, somewhat
-Unblinded the bird
Still to do:
-Lightning field/bird effect targets multiple body parts 
-Meditation UI prompt
-Spell Pool system